### PR TITLE
fixed a for loop using objects as indexes

### DIFF
--- a/src/pydio/job/scheduler.py
+++ b/src/pydio/job/scheduler.py
@@ -38,8 +38,7 @@ class PydioScheduler():
         dispatcher.connect(self.handle_generic_signal, signal=COMMAND_SIGNAL, sender=dispatcher.Any)
 
     def start_all(self):
-        for job_id in self.job_configs:
-            job_config = self.job_configs[job_id]
+        for job_config in self.job_configs:
             self.start_from_config(job_config)
 
     def pause_all(self):


### PR DESCRIPTION
Hi,

the job scheduler tries to use objects as indizes in the start_all for loop. This seems to have already been fixed in e.g. the pause_all loop, so sorry if this is fixed in some other branch (I did check a bit). This prevented me from using the program at all.

Cheers,
Michael

