### PR TITLE
Change abbrevation of minute to "min" from "mn" 

### DIFF
--- a/src/pydio/ui/res/project.js
+++ b/src/pydio/ui/res/project.js
@@ -69,7 +69,7 @@ angular.module('project', ['ngRoute', 'ngResource', 'ui.bootstrap', 'ui.bootstra
             if (isNaN(parseFloat(sec)) || !isFinite(sec)) return sec;
             var d=new Date(0,0,0, 0, 0, Math.round(sec));
             if(d.getHours() || d.getMinutes()){
-                return (d.getHours() ? d.getHours()+'h ' : '')+ (d.getMinutes() ? d.getMinutes()+'mn ':'');
+                return (d.getHours() ? d.getHours()+'h ' : '')+ (d.getMinutes() ? d.getMinutes()+'min ':'');
             }else{
                 return d.getSeconds() + 's';
             }


### PR DESCRIPTION
Hello,

As in subject. I believe "min" is common abbrevation for "minute".

Example changed view:
![zaznaczenie_209](https://cloud.githubusercontent.com/assets/3618479/12374871/f38e18b2-bcaa-11e5-8bb8-620111d3239c.png)

Greetings,
