### PR TITLE
Fix import + typo in sdkremote

### DIFF
--- a/src/pydio/sdklocal/local.py
+++ b/src/pydio/sdklocal/local.py
@@ -22,7 +22,10 @@ import os
 import hashlib
 import stat
 import netifaces
-from sdkremote.exceptions import SystemSdkException
+try:
+    from pydio.sdkremote.exceptions import SystemSdkException
+except ImportError:
+    from sdkremote.exceptions import SystemSdkException
 import shutil
 import logging
 try:


### PR DESCRIPTION
I have spotted a typo that makes all the import fail when I install from the sources. Since I've spent half an hour trying to find from where it was coming from, I let you benefit from the patch ;-)